### PR TITLE
Add smithy configuration

### DIFF
--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,0 +1,13 @@
+project: dart
+language: dart
+
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:203768 # Dart 1.24.2
+
+script:
+  - pub get --packages-dir
+  # Uncomment the line below when tests are written
+  # - xvfb-run -s '-screen 0 1024x768x24' pub run dart_dev test --pub-serve --web-compiler=dartdevc -p chrome -p vm
+
+artifacts:
+  build:
+    - ./pubspec.lock


### PR DESCRIPTION
This will ensure that Smithy is able to run. It doesn't strictly need to run tests, but it does need to run in order to ensure dependency check completes.

### +10
CI passes.