### PR TITLE
Release pdfjs_dart 1.11.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pdfjs
-version: 0.0.0
+version: 1.11.0
 
 description: Dart bindings for Mozilla's PDF.js library
 


### PR DESCRIPTION


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/pdfjs_dart/compare/1.10.90...Workiva:release_pdfjs_dart_1_11_0
Diff Between Last Tag and New Tag: https://github.com/Workiva/pdfjs_dart/compare/1.10.90...1.11.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6568135994376192/logs/)