### PR TITLE
Implement `DocumentInitParameters`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Dart
+.pub/
 .packages
 pubspec.lock
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: dart
+dart:
+  - 1.24.2
+script:
+  - npm install
+  - pub get
+  - pub run dart_dev format --check
+  - pub run dart_dev analyze

--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-Dart bindings for Mozilla's PDF.js library

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# pdfjs_dart
+[![Pub](https://img.shields.io/pub/v/pdfjs.svg)](https://pub.dartlang.org/packages/pdfjs)
+[![Build Status](https://travis-ci.org/Workiva/pdfjs_dart.svg?branch=master)](https://travis-ci.org/Workiva/pdfjs_dart)
+[![documentation](https://img.shields.io/badge/Documentation-pdfjs-blue.svg)](https://www.dartdocs.org/documentation/pdfjs/latest/)
+
+---
+
+**Dart bindings for Mozilla's PDF.js library**

--- a/lib/pdfjs.dart
+++ b/lib/pdfjs.dart
@@ -19,6 +19,7 @@ import 'dart:html';
 import 'dart:js';
 import 'dart:typed_data';
 
+part 'src/document_init_parameters.dart';
 part 'src/pdfjs_global.dart';
 part 'src/page_viewport.dart';
 part 'src/pdf_data_range_transport.dart';

--- a/lib/src/document_init_parameters.dart
+++ b/lib/src/document_init_parameters.dart
@@ -21,11 +21,11 @@ enum NativeImageDecoderSupport {
 }
 
 class DocumentInitParameters {
-  Map<String, dynamic> _jsInternal;
+  JsObject _jsInternal;
   PDFDataRangeTransport _range;
 
   DocumentInitParameters() {
-    _jsInternal = new Map<String, dynamic>();
+    _jsInternal = new JsObject.jsify({});
   }
 
   TypedData get data => _jsInternal['data'];
@@ -69,7 +69,7 @@ class DocumentInitParameters {
 
   PDFDataRangeTransport get range => _range;
   set range(PDFDataRangeTransport range) {
-    _jsInternal['range'] = range;
+    _jsInternal['range'] = range._jsInternal;
 
     // It's not ideal that we store this, but PDF.js shouldn't be setting this
     // property and we can't properly recreate the original object

--- a/lib/src/document_init_parameters.dart
+++ b/lib/src/document_init_parameters.dart
@@ -1,0 +1,122 @@
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of pdfjs;
+
+enum NativeImageDecoderSupport {
+  decode,
+  display,
+  none,
+}
+
+class DocumentInitParameters {
+  Map<String, dynamic> _jsInternal;
+  PDFDataRangeTransport _range;
+
+  DocumentInitParameters() {
+    _jsInternal = new Map<String, dynamic>();
+  }
+
+  TypedData get data => _jsInternal['data'];
+  set data(TypedData data) {
+    _jsInternal['data'] = data;
+  }
+
+  String get docBaseUrl => _jsInternal['docBaseUrl'];
+  set docBaseUrl(String docBaseUrl) {
+    _jsInternal['docBaseUrl'] = docBaseUrl;
+  }
+
+  TypedData get initialData => _jsInternal['initialData'];
+  set initialData(TypedData initialData) {
+    _jsInternal['initialData'] = initialData;
+  }
+
+  Map<String, dynamic> get httpHeaders => _jsInternal['httpHeaders'];
+  set httpHeaders(Map<String, dynamic> httpHeaders) {
+    _jsInternal['httpHeaders'] = httpHeaders;
+  }
+
+  int get length => _jsInternal['length'];
+  set length(int length) {
+    _jsInternal['length'] = length;
+  }
+
+  NativeImageDecoderSupport get nativeImageDecoderSupport =>
+      _nativeImageDecoderSupportPdfjsToDart[
+          _jsInternal['nativeImageDecoderSupport']];
+  set nativeImageDecoderSupport(
+      NativeImageDecoderSupport nativeImageDecoderSupport) {
+    _jsInternal['nativeImageDecoderSupport'] =
+        _nativeImageDecoderSupportDartToPdfjs[nativeImageDecoderSupport];
+  }
+
+  String get password => _jsInternal['password'];
+  set password(String password) {
+    _jsInternal['password'] = password;
+  }
+
+  PDFDataRangeTransport get range => _range;
+  set range(PDFDataRangeTransport range) {
+    _jsInternal['range'] = range;
+
+    // It's not ideal that we store this, but PDF.js shouldn't be setting this
+    // property and we can't properly recreate the original object
+    _range = range;
+  }
+
+  int get rangeChunkSize => _jsInternal['rangeChunkSize'];
+  set rangeChunkSize(int rangeChunkSize) {
+    _jsInternal['rangeChunkSize'] = rangeChunkSize;
+  }
+
+  bool get stopAtErrors => _jsInternal['stopAtErrors'];
+  set stopAtErrors(bool stopAtErrors) {
+    _jsInternal['stopAtErrors'] = stopAtErrors;
+  }
+
+  String get url => _jsInternal['url'];
+  set url(String url) {
+    _jsInternal['url'] = url;
+  }
+
+  bool get withCredentials => _jsInternal['withCredentials'];
+  set withCredentials(bool withCredentials) {
+    _jsInternal['withCredentials'] = withCredentials;
+  }
+
+  // FOOTGUN: Both this list and the following list must be kept in
+  // corresponding order
+  static List<String> _pdfjsNativeImageDecoderSupport = [
+    'decode',
+    'display',
+    'none',
+  ];
+
+  // FOOTGUN: Both this list and the preceding list must be kept in
+  // corresponding order
+  static List<NativeImageDecoderSupport> _dartNativeImageDecoderSupport = [
+    NativeImageDecoderSupport.decode,
+    NativeImageDecoderSupport.display,
+    NativeImageDecoderSupport.none,
+  ];
+
+  static Map<String, NativeImageDecoderSupport>
+      _nativeImageDecoderSupportPdfjsToDart = new Map.fromIterables(
+          _pdfjsNativeImageDecoderSupport, _dartNativeImageDecoderSupport);
+
+  static Map<NativeImageDecoderSupport, String>
+      _nativeImageDecoderSupportDartToPdfjs = new Map.fromIterables(
+          _dartNativeImageDecoderSupport, _pdfjsNativeImageDecoderSupport);
+}

--- a/lib/src/pdf_document_proxy.dart
+++ b/lib/src/pdf_document_proxy.dart
@@ -50,7 +50,8 @@ class PDFDocumentProxy {
   }
 
   Future<String> getPageMode() {
-    JsObject promise = _jsInternal['getPageMode'].apply([], thisArg: _jsInternal);
+    JsObject promise =
+        _jsInternal['getPageMode'].apply([], thisArg: _jsInternal);
 
     return _promiseToFuture<String>(promise);
   }

--- a/lib/src/pdf_page_view.dart
+++ b/lib/src/pdf_page_view.dart
@@ -62,7 +62,8 @@ class PDFPageView {
   }
 
   void setPdfPage(PDFPageProxy pdfPage) {
-    _jsInternal['setPdfPage'].apply([pdfPage._jsInternal], thisArg: _jsInternal);
+    _jsInternal['setPdfPage']
+        .apply([pdfPage._jsInternal], thisArg: _jsInternal);
   }
 
   void update(num scale, [num rotation = 0]) {

--- a/lib/src/pdfjs_global.dart
+++ b/lib/src/pdfjs_global.dart
@@ -144,6 +144,12 @@ class PDFJS {
     return new PDFDocumentLoadingTask._withJsInternal(documentTask);
   }
 
+  static PDFDocumentLoadingTask getDocumentByDocumentInitParameters(
+      DocumentInitParameters src) {
+    // ignore: deprecated_member_use
+    return getDocument(src._jsInternal);
+  }
+
   static PDFDocumentLoadingTask getDocumentByString(String src) {
     // ignore: deprecated_member_use
     return getDocument(src);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,4 +9,8 @@ authors:
   - Sean Burke <sean.burke@workiva.com>
 
 environment:
-  sdk: ">=1.24.0 <2.0.0"
+  sdk: '>=1.24.0 <2.0.0'
+
+dev_dependencies:
+  dart_dev: ^1.8.1
+  dart_style: ^1.0.8


### PR DESCRIPTION
Provide support for opening documents via `DocumentInitParameters` ([documentation](https://mozilla.github.io/pdf.js/api/draft/global.html#DocumentInitParameters)). This is provided as a strongly-typed dart object which wraps a raw JS object.

Also taking this opportunity to add a couple helpful badges to the README and try to get travis passing.