### PR TITLE
Implement `PDFDocumentProxy.getOutline()` and supporting functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ pubspec.lock
 # JavaScript
 node_modules/
 package-lock.json
+
+# IDEs
+.idea/

--- a/lib/pdfjs.dart
+++ b/lib/pdfjs.dart
@@ -15,6 +15,7 @@
 library pdfjs;
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:html';
 import 'dart:js';
 import 'dart:typed_data';

--- a/lib/src/page_viewport.dart
+++ b/lib/src/page_viewport.dart
@@ -24,7 +24,7 @@ class PageViewport {
   PageViewport._withJsInternal(this._jsInternal);
 
   PageViewport clone({num rotation, num scale}) {
-    JsObject viewport = _jsInternal['clone'].apply([], thisArg: _jsInternal);
+    JsObject viewport = _jsInternal.callMethod('clone', []);
 
     return new PageViewport._withJsInternal(viewport);
   }

--- a/lib/src/pdf_data_range_transport.dart
+++ b/lib/src/pdf_data_range_transport.dart
@@ -30,20 +30,20 @@ abstract class PDFDataRangeTransport {
   void abort() {}
 
   void onDataProgress(int loaded) {
-    _jsInternal['onDataProgress'].apply([loaded], thisArg: _jsInternal);
+    _jsInternal.callMethod('onDataProgress', [loaded]);
   }
 
   void onDataProgressiveRead(Uint8List chunk) {
-    _jsInternal['onDataProgressiveRead'].apply([chunk], thisArg: _jsInternal);
+    _jsInternal.callMethod('onDataProgressiveRead', [chunk]);
   }
 
   void onDataRange(int begin, Uint8List chunk) {
-    _jsInternal['onDataRange'].apply([begin, chunk], thisArg: _jsInternal);
+    _jsInternal.callMethod('onDataRange', [begin, chunk]);
   }
 
   void requestDataRange(int begin, int end);
 
   void transportReady() {
-    _jsInternal['transportReady'].apply([], thisArg: _jsInternal);
+    _jsInternal.callMethod('transportReady', []);
   }
 }

--- a/lib/src/pdf_document_loading_task.dart
+++ b/lib/src/pdf_document_loading_task.dart
@@ -38,8 +38,7 @@ class PDFDocumentLoadingTask {
 
   Future<PDFDocumentProxy> get future => _future;
 
-  Future destroy() =>
-      _promiseToFuture(_jsInternal['destroy'].apply([], thisArg: _jsInternal));
+  Future destroy() => _promiseToFuture(_jsInternal.callMethod('destroy', []));
 
   Future<S> then<S>(dynamic onValue(PDFDocumentProxy value),
           {Function onError}) =>

--- a/lib/src/pdf_document_proxy.dart
+++ b/lib/src/pdf_document_proxy.dart
@@ -14,6 +14,117 @@
 
 part of pdfjs;
 
+class PageReference {
+  JsObject _jsInternal;
+
+  PageReference._withJsInternal(this._jsInternal);
+
+  int get gen => _jsInternal['gen'];
+
+  int get num => _jsInternal['num'];
+}
+
+enum DestinationType { XYZ, Fit, FitH, FitV, FitR, FitB, FitBH, FitBV }
+
+DestinationType _destinationTypeFromString(String typeString) {
+  if (typeString == 'XYZ') {
+    return DestinationType.XYZ;
+  } else if (typeString == 'Fit') {
+    return DestinationType.Fit;
+  } else if (typeString == 'FitH') {
+    return DestinationType.FitH;
+  } else if (typeString == 'FitV') {
+    return DestinationType.FitV;
+  } else if (typeString == 'FitR') {
+    return DestinationType.FitR;
+  } else if (typeString == 'FitB') {
+    return DestinationType.FitB;
+  } else if (typeString == 'FitBH') {
+    return DestinationType.FitBH;
+  } else if (typeString == 'FitBV') {
+    return DestinationType.FitBV;
+  }
+
+  return null;
+}
+
+dynamic _dartifyDestination(dynamic jsDest) {
+  if (jsDest is List) {
+    return _dartifyExplicitDestination(jsDest);
+  } else {
+    return jsDest;
+  }
+}
+
+List<dynamic> _dartifyExplicitDestination(List<dynamic> jsDest) {
+  List<dynamic> dartDest = new List<dynamic>(jsDest.length);
+
+  // The first item is always a page ref; create a strongly-typed dart object
+  // for it
+  dartDest[0] = new PageReference._withJsInternal(jsDest[0]);
+
+  // The second item is always a string specifying the action to take on
+  // selecting the outline item
+  dartDest[1] = _destinationTypeFromString(jsDest[1]);
+
+  // Copy the remaining values, which should be numbers
+  dartDest.setRange(2, jsDest.length, jsDest, 2);
+
+  return dartDest;
+}
+
+List<OutlineItem> _dartifyOutlineItemList(List<JsObject> jsItems) {
+  if (jsItems == null) {
+    return null;
+  }
+
+  List<OutlineItem> items = new List<OutlineItem>();
+  for (JsObject jsItem in jsItems) {
+    OutlineItem item = new OutlineItem._withJsInternal(jsItem);
+
+    items.add(item);
+  }
+
+  return items;
+}
+
+class OutlineItem {
+  dynamic _dest;
+  Iterable<OutlineItem> _items;
+  JsObject _jsInternal;
+
+  OutlineItem._withJsInternal(this._jsInternal) {
+    _dest = _dartifyDestination(_jsInternal['dest']);
+  }
+
+  bool get bold => _jsInternal['bold'];
+
+  Uint8List get color => _jsInternal['color'];
+
+  int get count => _jsInternal['count'];
+
+  dynamic get dest => _dest;
+
+  bool get italic => _jsInternal['italic'];
+
+  Iterable<OutlineItem> get items {
+    if (_items == null) {
+      List<OutlineItem> convertedItems =
+          _dartifyOutlineItemList(_jsInternal['items']);
+
+      convertedItems ??= [];
+
+      _items = new UnmodifiableListView(convertedItems);
+    }
+
+    return _items;
+  }
+
+  String get title => _jsInternal['title'];
+
+  String get url => _jsInternal['url'];
+}
+
 class PDFDocumentProxy {
   JsObject _jsInternal;
 

--- a/lib/src/pdf_document_proxy.dart
+++ b/lib/src/pdf_document_proxy.dart
@@ -180,7 +180,7 @@ class PDFDocumentProxy {
   }
 
   Future<int> getPageIndex(PageReference ref) {
-    JsObject promise = _jsInternal.callMethod('getPageIndex', [ref]);
+    JsObject promise = _jsInternal.callMethod('getPageIndex', [ref._jsInternal]);
 
     return _promiseToFuture<int>(promise);
   }

--- a/lib/src/pdf_document_proxy.dart
+++ b/lib/src/pdf_document_proxy.dart
@@ -159,6 +159,12 @@ class PDFDocumentProxy {
         transform: (value) => _dartifyExplicitDestination(value));
   }
 
+  Future<List<String>> getJavaScript() {
+    JsObject promise = _jsInternal.callMethod('getJavaScript', []);
+
+    return _promiseToFuture<List<String>>(promise);
+  }
+
   Future<List<OutlineItem>> getOutline() {
     JsObject promise = _jsInternal.callMethod('getOutline', []);
 

--- a/lib/src/pdf_document_proxy.dart
+++ b/lib/src/pdf_document_proxy.dart
@@ -152,11 +152,31 @@ class PDFDocumentProxy {
     return _promiseToFuture<TypedData>(promise);
   }
 
+  Future<List<dynamic>> getDestination(String id) {
+    JsObject promise = _jsInternal.callMethod('getDestination', [id]);
+
+    return _promiseToFuture<List<dynamic>>(promise,
+        transform: (value) => _dartifyExplicitDestination(value));
+  }
+
+  Future<List<OutlineItem>> getOutline() {
+    JsObject promise = _jsInternal.callMethod('getOutline', []);
+
+    return _promiseToFuture<List<OutlineItem>>(promise,
+        transform: (value) => _dartifyOutlineItemList(value));
+  }
+
   Future<PDFPageProxy> getPage(int pageNumber) {
     JsObject promise = _jsInternal.callMethod('getPage', [pageNumber]);
 
     return _promiseToFuture<PDFPageProxy>(promise,
         transform: (value) => new PDFPageProxy._withJsInternal(value));
+  }
+
+  Future<int> getPageIndex(PageReference ref) {
+    JsObject promise = _jsInternal.callMethod('getPageIndex', [ref]);
+
+    return _promiseToFuture<int>(promise);
   }
 
   Future<String> getPageMode() {

--- a/lib/src/pdf_document_proxy.dart
+++ b/lib/src/pdf_document_proxy.dart
@@ -28,30 +28,28 @@ class PDFDocumentProxy {
   int get numPages => _jsInternal['numPages'];
 
   void cleanup() {
-    _jsInternal['cleanup'].apply([], thisArg: _jsInternal);
+    _jsInternal.callMethod('cleanup', []);
   }
 
   void destroy() {
-    _jsInternal['destroy'].apply([], thisArg: _jsInternal);
+    _jsInternal.callMethod('destroy', []);
   }
 
   Future<TypedData> getData() {
-    JsObject promise = _jsInternal['getData'].apply([], thisArg: _jsInternal);
+    JsObject promise = _jsInternal.callMethod('getData', []);
 
     return _promiseToFuture<TypedData>(promise);
   }
 
   Future<PDFPageProxy> getPage(int pageNumber) {
-    JsObject promise =
-        _jsInternal['getPage'].apply([pageNumber], thisArg: _jsInternal);
+    JsObject promise = _jsInternal.callMethod('getPage', [pageNumber]);
 
     return _promiseToFuture<PDFPageProxy>(promise,
         transform: (value) => new PDFPageProxy._withJsInternal(value));
   }
 
   Future<String> getPageMode() {
-    JsObject promise =
-        _jsInternal['getPageMode'].apply([], thisArg: _jsInternal);
+    JsObject promise = _jsInternal.callMethod('getPageMode', []);
 
     return _promiseToFuture<String>(promise);
   }

--- a/lib/src/pdf_document_proxy.dart
+++ b/lib/src/pdf_document_proxy.dart
@@ -26,7 +26,14 @@ class PageReference {
 
 enum DestinationType { XYZ, Fit, FitH, FitV, FitR, FitB, FitBH, FitBV }
 
-DestinationType _destinationTypeFromString(String typeString) {
+DestinationType _destinationTypeFromName(dynamic jsType) {
+  String typeString;
+  if (jsType is JsObject) {
+    typeString = jsType['name'];
+  } else if (jsType is String) {
+    typeString = jsType;
+  }
+
   if (typeString == 'XYZ') {
     return DestinationType.XYZ;
   } else if (typeString == 'Fit') {
@@ -63,9 +70,9 @@ List<dynamic> _dartifyExplicitDestination(List<dynamic> jsDest) {
   // for it
   dartDest[0] = new PageReference._withJsInternal(jsDest[0]);
 
-  // The second item is always a string specifying the action to take on
-  // selecting the outline item
-  dartDest[1] = _destinationTypeFromString(jsDest[1]);
+  // The second item is either a string or name object specifying the action to
+  // take on selecting the outline item
+  dartDest[1] = _destinationTypeFromName(jsDest[1]);
 
   // Copy the remaining values, which should be numbers
   dartDest.setRange(2, jsDest.length, jsDest, 2);

--- a/lib/src/pdf_document_proxy.dart
+++ b/lib/src/pdf_document_proxy.dart
@@ -180,7 +180,8 @@ class PDFDocumentProxy {
   }
 
   Future<int> getPageIndex(PageReference ref) {
-    JsObject promise = _jsInternal.callMethod('getPageIndex', [ref._jsInternal]);
+    JsObject promise =
+        _jsInternal.callMethod('getPageIndex', [ref._jsInternal]);
 
     return _promiseToFuture<int>(promise);
   }

--- a/lib/src/pdf_page_proxy.dart
+++ b/lib/src/pdf_page_proxy.dart
@@ -32,12 +32,12 @@ class PDFPageProxy {
   List<num> get view => _jsInternal['view'];
 
   void cleanup() {
-    _jsInternal['cleanup'].apply([], thisArg: _jsInternal);
+    _jsInternal.callMethod('cleanup', []);
   }
 
   PageViewport getViewport(num scale, [int rotate = null]) {
     JsObject jsViewport =
-        _jsInternal['getViewport'].apply([scale, rotate], thisArg: _jsInternal);
+        _jsInternal.callMethod('getViewport', [scale, rotate]);
 
     return new PageViewport._withJsInternal(jsViewport);
   }

--- a/lib/src/pdf_page_view.dart
+++ b/lib/src/pdf_page_view.dart
@@ -50,23 +50,22 @@ class PDFPageView {
   DivElement get div => _jsInternal['div'];
 
   void cancelRendering() {
-    _jsInternal['cancelRendering'].apply([], thisArg: _jsInternal);
+    _jsInternal.callMethod('cancelRendering', []);
   }
 
   void destroy() {
-    _jsInternal['destroy'].apply([], thisArg: _jsInternal);
+    _jsInternal.callMethod('destroy', []);
   }
 
   void draw() {
-    _jsInternal['draw'].apply([], thisArg: _jsInternal);
+    _jsInternal.callMethod('draw', []);
   }
 
   void setPdfPage(PDFPageProxy pdfPage) {
-    _jsInternal['setPdfPage']
-        .apply([pdfPage._jsInternal], thisArg: _jsInternal);
+    _jsInternal.callMethod('setPdfPage', [pdfPage._jsInternal]);
   }
 
   void update(num scale, [num rotation = 0]) {
-    _jsInternal['update'].apply([scale, rotation], thisArg: _jsInternal);
+    _jsInternal.callMethod('update', [scale, rotation]);
   }
 }


### PR DESCRIPTION
Provide the necessary types and methods to support document outline and related go-to-destination functionality.

Some cleanup and a bonus API method which didn't require any type manipulation here.