### PR TITLE
Release pdfjs_dart 1.10.90+2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pdfjs
-version: 1.10.90+2+1
+version: 1.10.90+2
 
 description: Dart bindings for Mozilla's PDF.js library
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pdfjs
-version: 1.10.90+1
+version: 1.10.90+2+1
 
 description: Dart bindings for Mozilla's PDF.js library
 


### PR DESCRIPTION

Pulls Included in Release:
* [Implement `PDFDocumentProxy.getOutline()` and supporting functionality](https://github.com/Workiva/pdfjs_dart/pull/11)


Requested by: @tomconnell-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/pdfjs_dart/compare/1.10.90...Workiva:release_pdfjs_dart_1_10_90+2
Diff Between Last Tag and New Tag: https://github.com/Workiva/pdfjs_dart/compare/1.10.90...1.10.90+2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6568135994376192/logs/)