### PR TITLE
Release pdfjs_dart 1.10.90+4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pdfjs
-version: 1.10.90+4+3
+version: 1.10.90+4
 
 description: Dart bindings for Mozilla's PDF.js library
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pdfjs
-version: 1.10.90+3
+version: 1.10.90+4+3
 
 description: Dart bindings for Mozilla's PDF.js library
 


### PR DESCRIPTION

Pull Requests included in release:
* [BUILDTOOLS-2329: Update Dockerfile to mirror smithy.yaml](https://github.com/Workiva/pdfjs_dart/pull/15)
* [af_new_drydock_image](https://github.com/Workiva/pdfjs_dart/pull/19)
* [HY-5956 fixes for dart 2](https://github.com/Workiva/pdfjs_dart/pull/20)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/pdfjs_dart/compare/1.10.90...Workiva:release_pdfjs_dart_1.10.90+4
Diff Between Last Tag and New Tag: https://github.com/Workiva/pdfjs_dart/compare/1.10.90...1.10.90+4

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6568135994376192/logs/)