### PR TITLE
Release pdfjs_dart 2.1.266

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pdfjs
-version: 2.1.266+4
+version: 2.1.266
 
 description: Dart bindings for Mozilla's PDF.js library
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pdfjs
-version: 1.10.90+4
+version: 2.1.266+4
 
 description: Dart bindings for Mozilla's PDF.js library
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Upgrade PDF.js to 2.1.266](https://github.com/Workiva/pdfjs_dart/pull/22)


Requested by: @theisensanders-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/pdfjs_dart/compare/1.10.90+4...Workiva:release_pdfjs_dart_2.1.266
Diff Between Last Tag and New Tag: https://github.com/Workiva/pdfjs_dart/compare/1.10.90+4...2.1.266

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6568135994376192/logs/)