### PR TITLE
CPLAT-8327: Post-Dart2 cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Dart
-.pub/
 .packages
 pubspec.lock
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: dart
-dart:
-  - 1.24.2
-  - 2.0.0
-script:
-  - npm install
-  - pub get
-  - dartfmt -n --set-exit-if-changed lib
-  - dartanalyzer lib
+
+jobs:
+  include:
+    - dart: 2.4.0
+      name: "SDK: 2.4.0"
+      script:
+        - dartanalyzer .
+    - dart: stable
+      name: "SDK: stable"
+      script:
+        - dartanalyzer .
+        - dartfmt -n --set-exit-if-changed .
+      name: "SDK: dev"
+      script:
+        - dartanalyzer .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,15 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:203768 as build
+FROM drydock-prod.workiva.net/workiva/dart2_base_image:1
 ARG NPM_TOKEN
-# Build Environment Vars
-ARG BUILD_ID
-ARG BUILD_NUMBER
-ARG BUILD_URL
-ARG GIT_COMMIT
-ARG GIT_BRANCH
-ARG GIT_TAG
-ARG GIT_COMMIT_RANGE
-ARG GIT_HEAD_URL
-ARG GIT_MERGE_HEAD
-ARG GIT_MERGE_BRANCH
+
+RUN apt-get update && apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get update && apt-get install -y nodejs npm
+
 WORKDIR /build/
 ADD . /build/
-RUN echo "installing npm packages"
-RUN npm install
-RUN echo "Starting the script sections" && \
-		pub get --packages-dir && \
-		echo "Script sections completed"
-ARG BUILD_ARTIFACTS_BUILD=/build/pubspec.lock
+RUN pub get
 
+RUN npm install
 RUN mkdir /audit/
 ARG BUILD_ARTIFACTS_AUDIT=/audit/*
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,12 +1,4 @@
 # analysis_options.yaml docs: https://www.dartlang.org/guides/language/analysis-options 
-analyzer:
-  # Strong mode is required. Applies to the current project.
-  strong-mode:
-    # When compiling to JS, both implicit options apply to the current 
-    # project and all dependencies. They are useful to find possible 
-    # Type fixes or areas for explicit typing.
-    implicit-casts: true
-    implicit-dynamic: true
 
 # ALL lint rules are included. Unused lints should be commented
 # out with a reason. An up to date list of all options is here
@@ -421,12 +413,6 @@ linter:
     # 0 issues
     - prefer_asserts_in_initializer_lists
 
-    # Prefer using a boolean as the assert condition.
-    # http://dart-lang.github.io/linter/lints/prefer_bool_in_asserts.html
-    # recommendation: optional
-    # 0 issues
-    - prefer_bool_in_asserts
-
     # Use collection literals when possible.
     # http://dart-lang.github.io/linter/lints/prefer_collection_literals.html
     # recommendation: recommended
@@ -591,12 +577,6 @@ linter:
     # recommendation: optional
     # 0 issues
     - sort_unnamed_constructors_first
-
-    # Place the `super` call last in a constructor initialization list.
-    # http://dart-lang.github.io/linter/lints/super_goes_last.html
-    # recommendation: optional
-    # 0 issues
-    - super_goes_last
 
     # Test type arguments in operator ==(Object other).
     # http://dart-lang.github.io/linter/lints/test_types_in_equals.html

--- a/lib/src/document_init_parameters.dart
+++ b/lib/src/document_init_parameters.dart
@@ -25,7 +25,7 @@ class DocumentInitParameters {
   PDFDataRangeTransport _range;
 
   DocumentInitParameters() {
-    _jsInternal = new JsObject.jsify({});
+    _jsInternal = JsObject.jsify({});
   }
 
   TypedData get data => _jsInternal['data'];
@@ -113,10 +113,10 @@ class DocumentInitParameters {
   ];
 
   static Map<String, NativeImageDecoderSupport>
-      _nativeImageDecoderSupportPdfjsToDart = new Map.fromIterables(
+      _nativeImageDecoderSupportPdfjsToDart = Map.fromIterables(
           _pdfjsNativeImageDecoderSupport, _dartNativeImageDecoderSupport);
 
   static Map<NativeImageDecoderSupport, String>
-      _nativeImageDecoderSupportDartToPdfjs = new Map.fromIterables(
+      _nativeImageDecoderSupportDartToPdfjs = Map.fromIterables(
           _dartNativeImageDecoderSupport, _pdfjsNativeImageDecoderSupport);
 }

--- a/lib/src/interfaces.dart
+++ b/lib/src/interfaces.dart
@@ -20,7 +20,7 @@ class AnnotationLayerBuilderOptions {
   PDFPageProxy _pdfPage;
 
   AnnotationLayerBuilderOptions() {
-    _jsInternal = new JsObject.jsify({});
+    _jsInternal = JsObject.jsify({});
   }
 
   IL10n get l10n => _l10n;
@@ -54,8 +54,7 @@ class AnnotationLayerBuilder {
   JsObject _jsInternal;
 
   AnnotationLayerBuilder(AnnotationLayerBuilderOptions options) {
-    _jsInternal =
-        new JsObject(context['pdfjsViewer']['AnnotationLayerBuilder'], [
+    _jsInternal = JsObject(context['pdfjsViewer']['AnnotationLayerBuilder'], [
       options,
     ]);
   }
@@ -74,8 +73,8 @@ abstract class IPDFAnnotationLayerFactory {
     _jsInternal['createAnnotationLayerBuilder'] =
         (DivElement pageDiv, JsObject jsPdfPage,
             [bool renderInteractiveForms, JsObject jsL10n]) {
-      PDFPageProxy pdfPage = new PDFPageProxy._withJsInternal(jsPdfPage);
-      IL10n l10n = new _JsIL10n._withJsInternal(jsL10n);
+      PDFPageProxy pdfPage = PDFPageProxy._withJsInternal(jsPdfPage);
+      IL10n l10n = _JsIL10n._withJsInternal(jsL10n);
 
       AnnotationLayerBuilder annotationLayerBuilder =
           createAnnotationLayerBuilder(pageDiv, pdfPage,
@@ -102,7 +101,7 @@ class DefaultTextLayerFactory implements IPDFTextLayerFactory {
 
   DefaultTextLayerFactory() {
     _jsInternal =
-        new JsObject(context['pdfjsViewer']['DefaultTextLayerFactory'], []);
+        JsObject(context['pdfjsViewer']['DefaultTextLayerFactory'], []);
   }
 }
 
@@ -110,8 +109,8 @@ class DefaultAnnotationLayerFactory implements IPDFAnnotationLayerFactory {
   JsObject _jsInternal;
 
   DefaultAnnotationLayerFactory() {
-    _jsInternal = new JsObject(
-        context['pdfjsViewer']['DefaultAnnotationLayerFactory'], []);
+    _jsInternal =
+        JsObject(context['pdfjsViewer']['DefaultAnnotationLayerFactory'], []);
   }
 
   AnnotationLayerBuilder createAnnotationLayerBuilder(
@@ -128,7 +127,7 @@ class DefaultAnnotationLayerFactory implements IPDFAnnotationLayerFactory {
       l10n?._jsInternal
     ]);
 
-    return new AnnotationLayerBuilder._withJsInternal(jsAnnotationLayerBuilder);
+    return AnnotationLayerBuilder._withJsInternal(jsAnnotationLayerBuilder);
   }
 }
 
@@ -154,8 +153,8 @@ class _JsIL10n implements IL10n {
   }
 
   Future<String> get(String key, Map args, String fallback) {
-    JsObject promise = _jsInternal
-        .callMethod('get', [key, new JsObject.jsify(args), fallback]);
+    JsObject promise =
+        _jsInternal.callMethod('get', [key, JsObject.jsify(args), fallback]);
 
     return _promiseToFuture<String>(promise);
   }

--- a/lib/src/interfaces.dart
+++ b/lib/src/interfaces.dart
@@ -88,8 +88,8 @@ abstract class IPDFAnnotationLayerFactory {
   AnnotationLayerBuilder createAnnotationLayerBuilder(
     DivElement pageDiv,
     PDFPageProxy pdfPage, {
-    IL10n l10n: null,
-    bool renderInteractiveForms: false,
+    IL10n l10n = null,
+    bool renderInteractiveForms = false,
   });
 }
 
@@ -117,8 +117,8 @@ class DefaultAnnotationLayerFactory implements IPDFAnnotationLayerFactory {
   AnnotationLayerBuilder createAnnotationLayerBuilder(
     DivElement pageDiv,
     PDFPageProxy pdfPage, {
-    IL10n l10n: null,
-    bool renderInteractiveForms: false,
+    IL10n l10n = null,
+    bool renderInteractiveForms = false,
   }) {
     JsObject jsAnnotationLayerBuilder = _jsInternal.callMethod(
         'createAnnotationLayerBuilder', [

--- a/lib/src/page_viewport.dart
+++ b/lib/src/page_viewport.dart
@@ -18,7 +18,7 @@ class PageViewport {
   JsObject _jsInternal;
 
   PageViewport() {
-    _jsInternal = new JsObject(context['pdfjsLib']['PageViewport']);
+    _jsInternal = JsObject(context['pdfjsLib']['PageViewport']);
   }
 
   PageViewport._withJsInternal(this._jsInternal);
@@ -26,6 +26,6 @@ class PageViewport {
   PageViewport clone({num rotation, num scale}) {
     JsObject viewport = _jsInternal.callMethod('clone', []);
 
-    return new PageViewport._withJsInternal(viewport);
+    return PageViewport._withJsInternal(viewport);
   }
 }

--- a/lib/src/pdf_data_range_transport.dart
+++ b/lib/src/pdf_data_range_transport.dart
@@ -18,7 +18,7 @@ abstract class PDFDataRangeTransport {
   JsObject _jsInternal;
 
   PDFDataRangeTransport(int length, Uint8List initialData) {
-    _jsInternal = new JsObject(context['pdfjsLib']['PDFDataRangeTransport'], [
+    _jsInternal = JsObject(context['pdfjsLib']['PDFDataRangeTransport'], [
       length,
       initialData,
     ]);

--- a/lib/src/pdf_document_loading_task.dart
+++ b/lib/src/pdf_document_loading_task.dart
@@ -19,7 +19,7 @@ class PDFDocumentLoadingTask {
   JsObject _jsInternal;
 
   PDFDocumentLoadingTask() {
-    _jsInternal = new JsObject(context['pdfjsLib']['PDFDocumentLoadingTask']);
+    _jsInternal = JsObject(context['pdfjsLib']['PDFDocumentLoadingTask']);
     _initFuture();
   }
 
@@ -29,7 +29,7 @@ class PDFDocumentLoadingTask {
 
   void _initFuture() {
     _future = _promiseToFuture<PDFDocumentProxy>(_jsInternal['promise'],
-        transform: (value) => new PDFDocumentProxy._withJsInternal(value));
+        transform: (value) => PDFDocumentProxy._withJsInternal(value));
   }
 
   bool get destroyed => _jsInternal['destroyed'];

--- a/lib/src/pdf_document_proxy.dart
+++ b/lib/src/pdf_document_proxy.dart
@@ -64,11 +64,11 @@ dynamic _dartifyDestination(dynamic jsDest) {
 }
 
 List<dynamic> _dartifyExplicitDestination(List<dynamic> jsDest) {
-  List<dynamic> dartDest = new List<dynamic>(jsDest.length);
+  List<dynamic> dartDest = List<dynamic>(jsDest.length);
 
   // The first item is always a page ref; create a strongly-typed dart object
   // for it
-  dartDest[0] = new PageReference._withJsInternal(jsDest[0]);
+  dartDest[0] = PageReference._withJsInternal(jsDest[0]);
 
   // The second item is either a string or name object specifying the action to
   // take on selecting the outline item
@@ -85,9 +85,9 @@ List<OutlineItem> _dartifyOutlineItemList(List<JsObject> jsItems) {
     return null;
   }
 
-  List<OutlineItem> items = new List<OutlineItem>();
+  List<OutlineItem> items = List<OutlineItem>();
   for (JsObject jsItem in jsItems) {
-    OutlineItem item = new OutlineItem._withJsInternal(jsItem);
+    OutlineItem item = OutlineItem._withJsInternal(jsItem);
 
     items.add(item);
   }
@@ -121,7 +121,7 @@ class OutlineItem {
 
       convertedItems ??= [];
 
-      _items = new UnmodifiableListView(convertedItems);
+      _items = UnmodifiableListView(convertedItems);
     }
 
     return _items;
@@ -136,7 +136,7 @@ class PDFDocumentProxy {
   JsObject _jsInternal;
 
   PDFDocumentProxy() {
-    _jsInternal = new JsObject(context['pdfjsLib']['PDFDocumentProxy']);
+    _jsInternal = JsObject(context['pdfjsLib']['PDFDocumentProxy']);
   }
 
   PDFDocumentProxy._withJsInternal(this._jsInternal);
@@ -183,7 +183,7 @@ class PDFDocumentProxy {
     JsObject promise = _jsInternal.callMethod('getPage', [pageNumber]);
 
     return _promiseToFuture<PDFPageProxy>(promise,
-        transform: (value) => new PDFPageProxy._withJsInternal(value));
+        transform: (value) => PDFPageProxy._withJsInternal(value));
   }
 
   Future<int> getPageIndex(PageReference ref) {

--- a/lib/src/pdf_page_proxy.dart
+++ b/lib/src/pdf_page_proxy.dart
@@ -18,7 +18,7 @@ class PDFPageProxy {
   JsObject _jsInternal;
 
   PDFPageProxy() {
-    _jsInternal = new JsObject(context['pdfjsLib']['PDFPageProxy']);
+    _jsInternal = JsObject(context['pdfjsLib']['PDFPageProxy']);
   }
 
   PDFPageProxy._withJsInternal(this._jsInternal);
@@ -38,13 +38,13 @@ class PDFPageProxy {
   PageViewport getViewport(num scale,
       {int rotation = null, bool dontFlip = null}) {
     JsObject jsViewport = _jsInternal.callMethod('getViewport', [
-      new JsObject.jsify({
+      JsObject.jsify({
         'scale': scale,
         'rotation': rotation,
         'dontFlip': dontFlip,
       })
     ]);
 
-    return new PageViewport._withJsInternal(jsViewport);
+    return PageViewport._withJsInternal(jsViewport);
   }
 }

--- a/lib/src/pdf_page_view.dart
+++ b/lib/src/pdf_page_view.dart
@@ -38,8 +38,8 @@ class PDFPageView {
         break;
     }
 
-    _jsInternal = new JsObject(context['pdfjsViewer']['PDFPageView'], [
-      new JsObject.jsify({
+    _jsInternal = JsObject(context['pdfjsViewer']['PDFPageView'], [
+      JsObject.jsify({
         'container': container,
         'id': id,
         'scale': scale,

--- a/lib/src/pdfjs_global.dart
+++ b/lib/src/pdfjs_global.dart
@@ -141,7 +141,7 @@ class PDFJS {
   static PDFDocumentLoadingTask getDocument(dynamic src) {
     JsObject documentTask = _pdfjsContext.callMethod('getDocument', [src]);
 
-    return new PDFDocumentLoadingTask._withJsInternal(documentTask);
+    return PDFDocumentLoadingTask._withJsInternal(documentTask);
   }
 
   static PDFDocumentLoadingTask getDocumentByDocumentInitParameters(
@@ -185,10 +185,10 @@ class PDFJS {
   ];
 
   static Map<int, VERBOSITY_LEVELS> _verbosityLevelsPdfjsToDart =
-      new Map.fromIterables(_pdfjsVerbosityLevels, _dartVerbosityLevels);
+      Map.fromIterables(_pdfjsVerbosityLevels, _dartVerbosityLevels);
 
   static Map<VERBOSITY_LEVELS, int> _verbosityLevelsDartToPdfjs =
-      new Map.fromIterables(_dartVerbosityLevels, _pdfjsVerbosityLevels);
+      Map.fromIterables(_dartVerbosityLevels, _pdfjsVerbosityLevels);
 
   // FOOTGUN: Both this list and the following list must be kept in
   // corresponding order
@@ -211,8 +211,8 @@ class PDFJS {
   ];
 
   static Map<int, LinkTarget> _linkTargetPdfjsToDart =
-      new Map.fromIterables(_pdfjsLinkTarget, _dartLinkTarget);
+      Map.fromIterables(_pdfjsLinkTarget, _dartLinkTarget);
 
   static Map<LinkTarget, int> _linkTargetDartToPdfjs =
-      new Map.fromIterables(_dartLinkTarget, _pdfjsLinkTarget);
+      Map.fromIterables(_dartLinkTarget, _pdfjsLinkTarget);
 }

--- a/lib/src/private.dart
+++ b/lib/src/private.dart
@@ -15,7 +15,7 @@
 part of pdfjs;
 
 Future<S> _promiseToFuture<S>(JsObject promise, {Function transform}) {
-  Completer completer = new Completer();
+  Completer completer = Completer();
 
   dynamic valueToDart(dynamic value) {
     if (transform != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,13 @@
 name: pdfjs
 version: 2.1.266
-
 description: Dart bindings for Mozilla's PDF.js library
-
+author: Sean Burke <sean.burke@workiva.com>
 homepage: https://github.com/Workiva/pdfjs_dart
 
-authors:
-  - Sean Burke <sean.burke@workiva.com>
-
 environment:
-  sdk: '>=1.24.0 <3.0.0'
+  sdk: '>=2.4.0 <3.0.0'
+
+dev_dependencies:
+  build_runner: ^1.7.1
+  build_test: ^0.10.9
+  build_web_compilers: ^2.5.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,3 @@ homepage: https://github.com/Workiva/pdfjs_dart
 
 environment:
   sdk: '>=2.4.0 <3.0.0'
-
-dev_dependencies:
-  build_runner: ^1.7.1
-  build_test: ^0.10.9
-  build_web_compilers: ^2.5.1


### PR DESCRIPTION
## Problem/Solution
We can remove dart1.
### Changes
- `dartfmt` fixes
- remove deprecated lints
- update `.travis.yaml`
- use base image
## Testing instructions
- [ ] CI should be sufficient