### PR TITLE
Try creating cdn artifact

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,9 @@ RUN npm install
 RUN mkdir /audit/
 ARG BUILD_ARTIFACTS_AUDIT=/audit/*
 
+# create cdn artifact
+RUN cd /build/lib && tar -cvzf /assets.tar.gz assets
+ARG BUILD_ARTIFACTS_CDN=/assets.tar.gz
+
 RUN npm ls -s --json --depth=10 > /audit/npm.lock || [ $? -eq 1 ] || exit
 FROM scratch


### PR DESCRIPTION
Going to look into a separate repo just for CDN assets: https://github.com/Workiva/pdfjs_cdn/pull/1/, e.g. to have an internal cdn version of https://cdnjs.com/libraries/pdf.js/2.6.347


Thread

[﻿cop-client-tech](https://workiva.slack.com/archives/CEENAH3RS/p1616429086002100)

I'm looking into dynamically loading different versions of pdfjs. Graph_app is pinned to [pdfjs: ^1.10.90+4](https://github.com/Workiva/w_viewer/blob/b9dff16254ebeb6705f388c85bcc53f088e6b018/pubspec.yaml#L52), whereas markup_client internally bundles ["pdfjs-dist": "2.5.207"](https://github.com/Workiva/markup_client/blob/ffb64cbdeba8cd6dfbca229ef84d48675d3aaf90/package.json#L16). Apparently, [When we upgraded to PDF.js 2.1.266, some PDFs brought into wDesk with highlights over content would block out the content below](https://github.com/Workiva/w_viewer/pull/620), so graph_app is pinned to a way-old version. I'd like to explore using [#launch-darkly](https://workiva.slack.com/archives/CTW35H3EJ) and a CDN do deliver different versions of pdfjs to either/both apps.Any tips on getting pdfjs assets on the CDN and loading from there instead of using the package path in [loadStaticAssets(StaticAssetLoader loader)](https://github.com/Workiva/graph_app/blob/473fe7d2bdb896d78f20dfe063500492898bb98d/lib/src/experiences/evidence_testing/experiences/evidence_testing/evidence_testing_experience_config.dart#L69-L73) ?


[maxwell.peterson](https://app.slack.com/team/UEDNL62RX)  [14 minutes ago](https://workiva.slack.com/archives/CEENAH3RS/p1616429276002500?thread_ts=1616429086.002100&cid=CEENAH3RS)

The LaunchDarkly piece could be as simple as a flag that stores a full CDN URL to the file.

[maxwell.peterson](https://app.slack.com/team/UEDNL62RX)  [13 minutes ago](https://workiva.slack.com/archives/CEENAH3RS/p1616429335002800?thread_ts=1616429086.002100&cid=CEENAH3RS)

As for publishing different versions of the file, I would try to publish the different versions of PDFJS from the same repo, with different file names

[maxwell.peterson](https://app.slack.com/team/UEDNL62RX)  [12 minutes ago](https://workiva.slack.com/archives/CEENAH3RS/p1616429367003000?thread_ts=1616429086.002100&cid=CEENAH3RS)

Any repo can publish a CDN artifact

[maxwell.peterson](https://app.slack.com/team/UEDNL62RX)  [10 minutes ago](https://workiva.slack.com/archives/CEENAH3RS/p1616429530003200?thread_ts=1616429086.002100&cid=CEENAH3RS)

Then I think you can still use `StaticAssetLoader.load()` , which will ensure your asset is only loaded once.

maxwell.peterson  8 minutes ago
A CDN artifact is just a directory of files, and those will be accessible in the same directory structure on the CDN. So you just need something that will stage a directory in your build with the desired CDN contents, and then set the environment variable that will make that directory your CDN artifact (might need to be tar’d up too)

maxwell.peterson  8 minutes ago
https://github.com/Workiva/wdesk_sdk_builders/blob/master/Dockerfile#L6-L8

maxwell.peterson  7 minutes ago
Where “assets” is just: https://github.com/Workiva/wdesk_sdk_builders/tree/master/lib/assets -> https://cdn-prod.wdesk.com/wdesk_sdk_builders/1.3.3/assets/ldclient.min.js

rob.becker:spiral_calendar_pad:  < 1 minute ago
Well, one option would be to setup a new rep and just call it pdfjs and put a dockerfile and publish all the versions of the JS you need. :shrug:
Then your URLs would look something like
`https://cdn-prod.wdesk.com/pdfjs/<repoversion>/pdf-<pdfjsversion>.min.js`

