### PR TITLE
[INTRISK-28406] Upgrade Pdfjs interop to v2.5.207 from markup_client

### DIFF
--- a/.dart_tool/package_config.json
+++ b/.dart_tool/package_config.json
@@ -1,0 +1,44 @@
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "matcher",
+      "rootUri": "file:///Users/pauldanner/.pub-cache/hosted/pub.dartlang.org/matcher-0.12.9",
+      "packageUri": "lib/",
+      "languageVersion": "2.7"
+    },
+    {
+      "name": "meta",
+      "rootUri": "file:///Users/pauldanner/.pub-cache/hosted/pub.dartlang.org/meta-1.2.4",
+      "packageUri": "lib/",
+      "languageVersion": "1.12"
+    },
+    {
+      "name": "path",
+      "rootUri": "file:///Users/pauldanner/.pub-cache/hosted/pub.dartlang.org/path-1.7.0",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "quiver",
+      "rootUri": "file:///Users/pauldanner/.pub-cache/hosted/pub.dartlang.org/quiver-2.1.5",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "stack_trace",
+      "rootUri": "file:///Users/pauldanner/.pub-cache/hosted/pub.dartlang.org/stack_trace-1.9.6",
+      "packageUri": "lib/",
+      "languageVersion": "2.0"
+    },
+    {
+      "name": "pdfjs",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "languageVersion": "2.4"
+    }
+  ],
+  "generated": "2021-07-12T18:01:06.181886Z",
+  "generator": "pub",
+  "generatorVersion": "2.7.2"
+}

--- a/lib/pdfjs.dart
+++ b/lib/pdfjs.dart
@@ -20,6 +20,8 @@ import 'dart:html';
 import 'dart:js';
 import 'dart:typed_data';
 
+import 'package:quiver/check.dart';
+
 part 'src/document_init_parameters.dart';
 part 'src/interfaces.dart';
 part 'src/pdfjs_global.dart';

--- a/lib/src/document_init_parameters.dart
+++ b/lib/src/document_init_parameters.dart
@@ -28,41 +28,38 @@ class DocumentInitParameters {
     _jsInternal = JsObject.jsify({});
   }
 
-  TypedData get data => _jsInternal['data'];
+  TypedData get data => _jsInternal['data'] as TypedData;
   set data(TypedData data) {
     _jsInternal['data'] = data;
   }
 
-  String get docBaseUrl => _jsInternal['docBaseUrl'];
+  String get docBaseUrl => _jsInternal['docBaseUrl'] as String;
   set docBaseUrl(String docBaseUrl) {
     _jsInternal['docBaseUrl'] = docBaseUrl;
   }
 
-  TypedData get initialData => _jsInternal['initialData'];
+  TypedData get initialData => _jsInternal['initialData'] as TypedData;
   set initialData(TypedData initialData) {
     _jsInternal['initialData'] = initialData;
   }
 
-  Map<String, dynamic> get httpHeaders => _jsInternal['httpHeaders'];
+  Map<String, dynamic> get httpHeaders => _jsInternal['httpHeaders'] as Map<String, dynamic>;
   set httpHeaders(Map<String, dynamic> httpHeaders) {
     _jsInternal['httpHeaders'] = httpHeaders;
   }
 
-  int get length => _jsInternal['length'];
+  int get length => _jsInternal['length'] as int;
   set length(int length) {
     _jsInternal['length'] = length;
   }
 
   NativeImageDecoderSupport get nativeImageDecoderSupport =>
-      _nativeImageDecoderSupportPdfjsToDart[
-          _jsInternal['nativeImageDecoderSupport']];
-  set nativeImageDecoderSupport(
-      NativeImageDecoderSupport nativeImageDecoderSupport) {
-    _jsInternal['nativeImageDecoderSupport'] =
-        _nativeImageDecoderSupportDartToPdfjs[nativeImageDecoderSupport];
+      _nativeImageDecoderSupportPdfjsToDart[_jsInternal['nativeImageDecoderSupport']];
+  set nativeImageDecoderSupport(NativeImageDecoderSupport nativeImageDecoderSupport) {
+    _jsInternal['nativeImageDecoderSupport'] = _nativeImageDecoderSupportDartToPdfjs[nativeImageDecoderSupport];
   }
 
-  String get password => _jsInternal['password'];
+  String get password => _jsInternal['password'] as String;
   set password(String password) {
     _jsInternal['password'] = password;
   }
@@ -76,22 +73,22 @@ class DocumentInitParameters {
     _range = range;
   }
 
-  int get rangeChunkSize => _jsInternal['rangeChunkSize'];
+  int get rangeChunkSize => _jsInternal['rangeChunkSize'] as int;
   set rangeChunkSize(int rangeChunkSize) {
     _jsInternal['rangeChunkSize'] = rangeChunkSize;
   }
 
-  bool get stopAtErrors => _jsInternal['stopAtErrors'];
+  bool get stopAtErrors => _jsInternal['stopAtErrors'] as bool;
   set stopAtErrors(bool stopAtErrors) {
     _jsInternal['stopAtErrors'] = stopAtErrors;
   }
 
-  String get url => _jsInternal['url'];
+  String get url => _jsInternal['url'] as String;
   set url(String url) {
     _jsInternal['url'] = url;
   }
 
-  bool get withCredentials => _jsInternal['withCredentials'];
+  bool get withCredentials => _jsInternal['withCredentials'] as bool;
   set withCredentials(bool withCredentials) {
     _jsInternal['withCredentials'] = withCredentials;
   }
@@ -112,11 +109,9 @@ class DocumentInitParameters {
     NativeImageDecoderSupport.none,
   ];
 
-  static Map<String, NativeImageDecoderSupport>
-      _nativeImageDecoderSupportPdfjsToDart = Map.fromIterables(
-          _pdfjsNativeImageDecoderSupport, _dartNativeImageDecoderSupport);
+  static Map<String, NativeImageDecoderSupport> _nativeImageDecoderSupportPdfjsToDart =
+      Map.fromIterables(_pdfjsNativeImageDecoderSupport, _dartNativeImageDecoderSupport);
 
-  static Map<NativeImageDecoderSupport, String>
-      _nativeImageDecoderSupportDartToPdfjs = Map.fromIterables(
-          _dartNativeImageDecoderSupport, _pdfjsNativeImageDecoderSupport);
+  static Map<NativeImageDecoderSupport, String> _nativeImageDecoderSupportDartToPdfjs =
+      Map.fromIterables(_dartNativeImageDecoderSupport, _pdfjsNativeImageDecoderSupport);
 }

--- a/lib/src/interfaces.dart
+++ b/lib/src/interfaces.dart
@@ -30,7 +30,7 @@ class AnnotationLayerBuilderOptions {
     _l10n = l10n;
   }
 
-  DivElement get pageDiv => _jsInternal['pageDiv'];
+  DivElement get pageDiv => _jsInternal['pageDiv'] as DivElement;
   set pageDiv(DivElement pageDiv) {
     _jsInternal['pageDiv'] = pageDiv;
   }
@@ -42,7 +42,7 @@ class AnnotationLayerBuilderOptions {
     _pdfPage = pdfPage;
   }
 
-  bool get renderInteractiveForms => _jsInternal['renderInteractiveForms'];
+  bool get renderInteractiveForms => _jsInternal['renderInteractiveForms'] as bool;
   set renderInteractiveForms(bool renderInteractiveForms) {
     _jsInternal['renderInteractiveForms'] = renderInteractiveForms;
   }
@@ -54,7 +54,7 @@ class AnnotationLayerBuilder {
   JsObject _jsInternal;
 
   AnnotationLayerBuilder(AnnotationLayerBuilderOptions options) {
-    _jsInternal = JsObject(context['pdfjsViewer']['AnnotationLayerBuilder'], [
+    _jsInternal = JsObject(context['pdfjsViewer']['AnnotationLayerBuilder'] as JsFunction, [
       options,
     ]);
   }
@@ -71,14 +71,16 @@ abstract class IPDFAnnotationLayerFactory {
 
   IPDFAnnotationLayerFactory() {
     _jsInternal['createAnnotationLayerBuilder'] =
-        (DivElement pageDiv, JsObject jsPdfPage,
-            [bool renderInteractiveForms, JsObject jsL10n]) {
+        (DivElement pageDiv, JsObject jsPdfPage, [bool renderInteractiveForms, JsObject jsL10n]) {
       PDFPageProxy pdfPage = PDFPageProxy._withJsInternal(jsPdfPage);
       IL10n l10n = _JsIL10n._withJsInternal(jsL10n);
 
-      AnnotationLayerBuilder annotationLayerBuilder =
-          createAnnotationLayerBuilder(pageDiv, pdfPage,
-              l10n: l10n, renderInteractiveForms: renderInteractiveForms);
+      AnnotationLayerBuilder annotationLayerBuilder = createAnnotationLayerBuilder(
+        pageDiv,
+        pdfPage,
+        l10n: l10n,
+        renderInteractiveForms: renderInteractiveForms,
+      );
 
       return annotationLayerBuilder._jsInternal;
     };
@@ -100,8 +102,7 @@ class DefaultTextLayerFactory implements IPDFTextLayerFactory {
   JsObject _jsInternal;
 
   DefaultTextLayerFactory() {
-    _jsInternal =
-        JsObject(context['pdfjsViewer']['DefaultTextLayerFactory'], []);
+    _jsInternal = JsObject(context['pdfjsViewer']['DefaultTextLayerFactory'] as JsFunction, []);
   }
 }
 
@@ -109,8 +110,7 @@ class DefaultAnnotationLayerFactory implements IPDFAnnotationLayerFactory {
   JsObject _jsInternal;
 
   DefaultAnnotationLayerFactory() {
-    _jsInternal =
-        JsObject(context['pdfjsViewer']['DefaultAnnotationLayerFactory'], []);
+    _jsInternal = JsObject(context['pdfjsViewer']['DefaultAnnotationLayerFactory'] as JsFunction, []);
   }
 
   AnnotationLayerBuilder createAnnotationLayerBuilder(
@@ -120,12 +120,8 @@ class DefaultAnnotationLayerFactory implements IPDFAnnotationLayerFactory {
     bool renderInteractiveForms = false,
   }) {
     JsObject jsAnnotationLayerBuilder = _jsInternal.callMethod(
-        'createAnnotationLayerBuilder', [
-      pageDiv,
-      pdfPage._jsInternal,
-      renderInteractiveForms,
-      l10n?._jsInternal
-    ]);
+            'createAnnotationLayerBuilder', [pageDiv, pdfPage._jsInternal, renderInteractiveForms, l10n?._jsInternal])
+        as JsObject;
 
     return AnnotationLayerBuilder._withJsInternal(jsAnnotationLayerBuilder);
   }
@@ -147,20 +143,19 @@ class _JsIL10n implements IL10n {
   _JsIL10n._withJsInternal(this._jsInternal);
 
   Future<String> getDirection() {
-    JsObject promise = _jsInternal.callMethod('getDirection', []);
+    JsObject promise = _jsInternal.callMethod('getDirection', []) as JsObject;
 
     return _promiseToFuture<String>(promise);
   }
 
   Future<String> get(String key, Map args, String fallback) {
-    JsObject promise =
-        _jsInternal.callMethod('get', [key, JsObject.jsify(args), fallback]);
+    JsObject promise = _jsInternal.callMethod('get', [key, JsObject.jsify(args), fallback]) as JsObject;
 
     return _promiseToFuture<String>(promise);
   }
 
   Future<Null> translate(HtmlElement element) {
-    JsObject promise = _jsInternal.callMethod('translate', [element]);
+    JsObject promise = _jsInternal.callMethod('translate', [element]) as JsObject;
 
     return _promiseToFuture<Null>(promise);
   }

--- a/lib/src/page_viewport.dart
+++ b/lib/src/page_viewport.dart
@@ -18,13 +18,13 @@ class PageViewport {
   JsObject _jsInternal;
 
   PageViewport() {
-    _jsInternal = JsObject(context['pdfjsLib']['PageViewport']);
+    _jsInternal = JsObject(context['pdfjsLib']['PageViewport'] as JsFunction);
   }
 
   PageViewport._withJsInternal(this._jsInternal);
 
   PageViewport clone({num rotation, num scale}) {
-    JsObject viewport = _jsInternal.callMethod('clone', []);
+    JsObject viewport = _jsInternal.callMethod('clone', []) as JsObject;
 
     return PageViewport._withJsInternal(viewport);
   }

--- a/lib/src/pdf_data_range_transport.dart
+++ b/lib/src/pdf_data_range_transport.dart
@@ -18,7 +18,7 @@ abstract class PDFDataRangeTransport {
   JsObject _jsInternal;
 
   PDFDataRangeTransport(int length, Uint8List initialData) {
-    _jsInternal = JsObject(context['pdfjsLib']['PDFDataRangeTransport'], [
+    _jsInternal = JsObject(context['pdfjsLib']['PDFDataRangeTransport'] as JsFunction, [
       length,
       initialData,
     ]);

--- a/lib/src/pdf_document_loading_task.dart
+++ b/lib/src/pdf_document_loading_task.dart
@@ -19,7 +19,7 @@ class PDFDocumentLoadingTask {
   JsObject _jsInternal;
 
   PDFDocumentLoadingTask() {
-    _jsInternal = JsObject(context['pdfjsLib']['PDFDocumentLoadingTask']);
+    _jsInternal = JsObject(context['pdfjsLib']['PDFDocumentLoadingTask'] as JsFunction);
     _initFuture();
   }
 
@@ -28,19 +28,18 @@ class PDFDocumentLoadingTask {
   }
 
   void _initFuture() {
-    _future = _promiseToFuture<PDFDocumentProxy>(_jsInternal['promise'],
-        transform: (value) => PDFDocumentProxy._withJsInternal(value));
+    _future = _promiseToFuture<PDFDocumentProxy>(_jsInternal['promise'] as JsObject,
+        transform: (value) => PDFDocumentProxy._withJsInternal(value as JsObject));
   }
 
-  bool get destroyed => _jsInternal['destroyed'];
+  bool get destroyed => _jsInternal['destroyed'] as bool;
 
-  String get docId => _jsInternal['docId'];
+  String get docId => _jsInternal['docId'] as String;
 
   Future<PDFDocumentProxy> get future => _future;
 
-  Future destroy() => _promiseToFuture(_jsInternal.callMethod('destroy', []));
+  Future destroy() => _promiseToFuture(_jsInternal.callMethod('destroy', []) as JsObject);
 
-  Future<S> then<S>(dynamic onValue(PDFDocumentProxy value),
-          {Function onError}) =>
+  Future<S> then<S>(FutureOr<S> onValue(PDFDocumentProxy value), {Function onError}) =>
       _future.then(onValue, onError: onError);
 }

--- a/lib/src/pdf_document_proxy.dart
+++ b/lib/src/pdf_document_proxy.dart
@@ -19,9 +19,9 @@ class PageReference {
 
   PageReference._withJsInternal(this._jsInternal);
 
-  int get gen => _jsInternal['gen'];
+  int get gen => _jsInternal['gen'] as int;
 
-  int get num => _jsInternal['num'];
+  int get num => _jsInternal['num'] as int;
 }
 
 enum DestinationType { XYZ, Fit, FitH, FitV, FitR, FitB, FitBH, FitBV }
@@ -29,7 +29,7 @@ enum DestinationType { XYZ, Fit, FitH, FitV, FitR, FitB, FitBH, FitBV }
 DestinationType _destinationTypeFromName(dynamic jsType) {
   String typeString;
   if (jsType is JsObject) {
-    typeString = jsType['name'];
+    typeString = jsType['name'] as String;
   } else if (jsType is String) {
     typeString = jsType;
   }
@@ -68,7 +68,7 @@ List<dynamic> _dartifyExplicitDestination(List<dynamic> jsDest) {
 
   // The first item is always a page ref; create a strongly-typed dart object
   // for it
-  dartDest[0] = PageReference._withJsInternal(jsDest[0]);
+  dartDest[0] = PageReference._withJsInternal(jsDest[0] as JsObject);
 
   // The second item is either a string or name object specifying the action to
   // take on selecting the outline item
@@ -104,20 +104,19 @@ class OutlineItem {
     _dest = _dartifyDestination(_jsInternal['dest']);
   }
 
-  bool get bold => _jsInternal['bold'];
+  bool get bold => _jsInternal['bold'] as bool;
 
-  Uint8List get color => _jsInternal['color'];
+  Uint8List get color => _jsInternal['color'] as Uint8List;
 
-  int get count => _jsInternal['count'];
+  int get count => _jsInternal['count'] as int;
 
   dynamic get dest => _dest;
 
-  bool get italic => _jsInternal['italic'];
+  bool get italic => _jsInternal['italic'] as bool;
 
   Iterable<OutlineItem> get items {
     if (_items == null) {
-      List<OutlineItem> convertedItems =
-          _dartifyOutlineItemList(_jsInternal['items']);
+      List<OutlineItem> convertedItems = _dartifyOutlineItemList(_jsInternal['items'] as List<JsObject>);
 
       convertedItems ??= [];
 
@@ -127,23 +126,23 @@ class OutlineItem {
     return _items;
   }
 
-  String get title => _jsInternal['title'];
+  String get title => _jsInternal['title'] as String;
 
-  String get url => _jsInternal['url'];
+  String get url => _jsInternal['url'] as String;
 }
 
 class PDFDocumentProxy {
   JsObject _jsInternal;
 
   PDFDocumentProxy() {
-    _jsInternal = JsObject(context['pdfjsLib']['PDFDocumentProxy']);
+    _jsInternal = JsObject(context['pdfjsLib']['PDFDocumentProxy'] as JsFunction);
   }
 
   PDFDocumentProxy._withJsInternal(this._jsInternal);
 
-  String get fingerprint => _jsInternal['fingerprint'];
+  String get fingerprint => _jsInternal['fingerprint'] as String;
 
-  int get numPages => _jsInternal['numPages'];
+  int get numPages => _jsInternal['numPages'] as int;
 
   void cleanup() {
     _jsInternal.callMethod('cleanup', []);
@@ -154,47 +153,45 @@ class PDFDocumentProxy {
   }
 
   Future<TypedData> getData() {
-    JsObject promise = _jsInternal.callMethod('getData', []);
+    JsObject promise = _jsInternal.callMethod('getData', []) as JsObject;
 
     return _promiseToFuture<TypedData>(promise);
   }
 
   Future<List<dynamic>> getDestination(String id) {
-    JsObject promise = _jsInternal.callMethod('getDestination', [id]);
+    JsObject promise = _jsInternal.callMethod('getDestination', [id]) as JsObject;
 
-    return _promiseToFuture<List<dynamic>>(promise,
-        transform: (value) => _dartifyExplicitDestination(value));
+    return _promiseToFuture<List<dynamic>>(promise, transform: (value) => _dartifyExplicitDestination(value as List));
   }
 
   Future<List<String>> getJavaScript() {
-    JsObject promise = _jsInternal.callMethod('getJavaScript', []);
+    JsObject promise = _jsInternal.callMethod('getJavaScript', []) as JsObject;
 
     return _promiseToFuture<List<String>>(promise);
   }
 
   Future<List<OutlineItem>> getOutline() {
-    JsObject promise = _jsInternal.callMethod('getOutline', []);
+    JsObject promise = _jsInternal.callMethod('getOutline', []) as JsObject;
 
     return _promiseToFuture<List<OutlineItem>>(promise,
-        transform: (value) => _dartifyOutlineItemList(value));
+        transform: (value) => _dartifyOutlineItemList(value as List<JsObject>));
   }
 
   Future<PDFPageProxy> getPage(int pageNumber) {
-    JsObject promise = _jsInternal.callMethod('getPage', [pageNumber]);
+    JsObject promise = _jsInternal.callMethod('getPage', [pageNumber]) as JsObject;
 
     return _promiseToFuture<PDFPageProxy>(promise,
-        transform: (value) => PDFPageProxy._withJsInternal(value));
+        transform: (value) => PDFPageProxy._withJsInternal(value as JsObject));
   }
 
   Future<int> getPageIndex(PageReference ref) {
-    JsObject promise =
-        _jsInternal.callMethod('getPageIndex', [ref._jsInternal]);
+    JsObject promise = _jsInternal.callMethod('getPageIndex', [ref._jsInternal]) as JsObject;
 
     return _promiseToFuture<int>(promise);
   }
 
   Future<String> getPageMode() {
-    JsObject promise = _jsInternal.callMethod('getPageMode', []);
+    JsObject promise = _jsInternal.callMethod('getPageMode', []) as JsObject;
 
     return _promiseToFuture<String>(promise);
   }

--- a/lib/src/pdf_document_proxy.dart
+++ b/lib/src/pdf_document_proxy.dart
@@ -174,7 +174,11 @@ class PDFDocumentProxy {
     JsObject promise = _jsInternal.callMethod('getOutline', []) as JsObject;
 
     return _promiseToFuture<List<OutlineItem>>(promise,
-        transform: (value) => _dartifyOutlineItemList(value as List<JsObject>));
+        transform: (value) {
+      if (value is List<JsObject>) {
+        _dartifyOutlineItemList(value as List<JsObject>);
+      }
+    });
   }
 
   Future<PDFPageProxy> getPage(int pageNumber) {

--- a/lib/src/pdf_page_proxy.dart
+++ b/lib/src/pdf_page_proxy.dart
@@ -18,33 +18,48 @@ class PDFPageProxy {
   JsObject _jsInternal;
 
   PDFPageProxy() {
-    _jsInternal = JsObject(context['pdfjsLib']['PDFPageProxy']);
+    checkNotNull(context, message: 'context was null in PDFPageProxy');
+    final pdfjsLib = context['pdfjsLib'];
+    checkState(pdfjsLib != null, message: 'pdfjsLib was null in PDFPageProxy');
+    final pdfPageProxyJs = pdfjsLib['PDFPageProxy'];
+    checkState(pdfPageProxyJs != null, message: 'pdfPageProxyJs was null in PDFPageProxy');
+    _jsInternal = JsObject(pdfPageProxyJs as JsFunction);
   }
 
   PDFPageProxy._withJsInternal(this._jsInternal);
 
-  int get pageNumber => _jsInternal['pageNumber'];
+  int get pageNumber => _jsInternal['pageNumber'] as int;
 
-  int get rotate => _jsInternal['rotate'];
+  int get rotate => _jsInternal['rotate'] as int;
 
-  num get userUnit => _jsInternal['userUnit'];
+  num get userUnit => _jsInternal['userUnit'] as num;
 
-  List<num> get view => _jsInternal['view'];
+  JsArray<dynamic> get view => _jsInternal['view'] as JsArray<dynamic>;
 
   void cleanup() {
     _jsInternal.callMethod('cleanup', []);
   }
 
-  PageViewport getViewport(num scale,
-      {int rotation = null, bool dontFlip = null}) {
-    JsObject jsViewport = _jsInternal.callMethod('getViewport', [
+  PageViewport getViewport(
+    num scale, {
+    int rotation,
+    bool dontFlip,
+  }) {
+    final jsViewport = _jsInternal.callMethod('getViewport', [
       JsObject.jsify({
         'scale': scale,
         'rotation': rotation,
         'dontFlip': dontFlip,
       })
-    ]);
+    ]) as JsObject;
 
     return PageViewport._withJsInternal(jsViewport);
   }
+
+  /// Get a map of prop values useful for logging context
+  Map<String, dynamic> toContext({String prefix = 'PDFPageProxy'}) => {
+        '$prefix.pageNumber': pageNumber,
+        '$prefix.rotate': rotate,
+        '$prefix.userUnit': userUnit,
+      };
 }

--- a/lib/src/pdf_page_view.dart
+++ b/lib/src/pdf_page_view.dart
@@ -38,7 +38,7 @@ class PDFPageView {
         break;
     }
 
-    _jsInternal = JsObject(context['pdfjsViewer']['PDFPageView'], [
+    _jsInternal = JsObject(context['pdfjsViewer']['PDFPageView'] as JsFunction, [
       JsObject.jsify({
         'container': container,
         'id': id,
@@ -47,11 +47,12 @@ class PDFPageView {
         'renderer': rendererString,
         'annotationLayerFactory': annotationLayerFactory?._jsInternal,
         'textLayerFactory': textLayerFactory?._jsInternal,
+        'eventBus': JsObject(context['pdfjsViewer']['EventBus'] as JsFunction),
       })
     ]);
   }
 
-  DivElement get div => _jsInternal['div'];
+  DivElement get div => _jsInternal['div'] as DivElement;
 
   void cancelRendering() {
     _jsInternal.callMethod('cancelRendering', []);

--- a/lib/src/pdfjs_global.dart
+++ b/lib/src/pdfjs_global.dart
@@ -29,108 +29,104 @@ enum VERBOSITY_LEVELS {
 }
 
 class PDFJS {
-  static final JsObject _pdfjsContext = context['pdfjsLib'];
+  static final JsObject _pdfjsContext = context['pdfjsLib'] as JsObject;
 
-  static bool get cMapPacked => _pdfjsContext['cMapPacked'];
+  static bool get cMapPacked => _pdfjsContext['cMapPacked'] as bool;
   static set cMapPacked(bool cMapPacked) {
     _pdfjsContext['cMapPacked'] = cMapPacked;
   }
 
-  static String get cMapUrl => _pdfjsContext['cMapUrl'];
+  static String get cMapUrl => _pdfjsContext['cMapUrl'] as String;
   static set cMapUrl(String cMapUrl) {
     _pdfjsContext['cMapUrl'] = cMapUrl;
   }
 
-  static bool get disableAutoFetch => _pdfjsContext['disableAutoFetch'];
+  static bool get disableAutoFetch => _pdfjsContext['disableAutoFetch'] as bool;
   static set disableAutoFetch(bool disableAutoFetch) {
     _pdfjsContext['disableAutoFetch'] = disableAutoFetch;
   }
 
-  static bool get disableCreateObjectURL =>
-      _pdfjsContext['disableCreateObjectURL'];
+  static bool get disableCreateObjectURL => _pdfjsContext['disableCreateObjectURL'] as bool;
   static set disableCreateObjectURL(bool disableCreateObjectURL) {
     _pdfjsContext['disableCreateObjectURL'] = disableCreateObjectURL;
   }
 
-  static bool get disableFontFace => _pdfjsContext['disableFontFace'];
+  static bool get disableFontFace => _pdfjsContext['disableFontFace'] as bool;
   static set disableFontFace(bool disableFontFace) {
     _pdfjsContext['disableFontFace'] = disableFontFace;
   }
 
-  static bool get disableRange => _pdfjsContext['disableRange'];
+  static bool get disableRange => _pdfjsContext['disableRange'] as bool;
   static set disableRange(bool disableRange) {
     _pdfjsContext['disableRange'] = disableRange;
   }
 
-  static bool get disableStream => _pdfjsContext['disableStream'];
+  static bool get disableStream => _pdfjsContext['disableStream'] as bool;
   static set disableStream(bool disableStream) {
     _pdfjsContext['disableStream'] = disableStream;
   }
 
-  static bool get disableWebGL => _pdfjsContext['disableWebGL'];
+  static bool get disableWebGL => _pdfjsContext['disableWebGL'] as bool;
   static set disableWebGL(bool disableWebGL) {
     _pdfjsContext['disableWebGL'] = disableWebGL;
   }
 
-  static bool get disableWorker => _pdfjsContext['disableWorker'];
+  static bool get disableWorker => _pdfjsContext['disableWorker'] as bool;
   static set disableWorker(bool disableWorker) {
     _pdfjsContext['disableWorker'] = disableWorker;
   }
 
-  static String get externalLinkRel => _pdfjsContext['externalLinkRel'];
+  static String get externalLinkRel => _pdfjsContext['externalLinkRel'] as String;
   static set externalLinkRel(String externalLinkRel) {
     _pdfjsContext['externalLinkRel'] = externalLinkRel;
   }
 
-  static LinkTarget get externalLinkTarget =>
-      _linkTargetPdfjsToDart[_pdfjsContext['externalLinkTarget']];
+  static LinkTarget get externalLinkTarget => _linkTargetPdfjsToDart[_pdfjsContext['externalLinkTarget']];
   static set externalLinkTarget(LinkTarget externalLinkTarget) {
-    _pdfjsContext['externalLinkTarget'] =
-        _linkTargetDartToPdfjs[externalLinkTarget];
+    _pdfjsContext['externalLinkTarget'] = _linkTargetDartToPdfjs[externalLinkTarget];
   }
 
-  static String get imageResourcesPath => _pdfjsContext['imageResourcesPath'];
+  static String get imageResourcesPath => _pdfjsContext['imageResourcesPath'] as String;
   static set imageResourcesPath(String imageResourcesPath) {
     _pdfjsContext['imageResourcesPath'] = imageResourcesPath;
   }
 
-  static bool get isEvalSupported => _pdfjsContext['isEvalSupported'];
+  static bool get isEvalSupported => _pdfjsContext['isEvalSupported'] as bool;
   static set isEvalSupported(bool isEvalSupported) {
     _pdfjsContext['isEvalSupported'] = isEvalSupported;
   }
 
-  static int get maxImageSize => _pdfjsContext['maxImageSize'];
+  static int get maxImageSize => _pdfjsContext['maxImageSize'] as int;
   static set maxImageSize(int maxImageSize) {
     _pdfjsContext['maxImageSize'] = maxImageSize;
   }
 
-  static bool get pdfBug => _pdfjsContext['pdfBug'];
+  static bool get pdfBug => _pdfjsContext['pdfBug'] as bool;
   static set pdfBug(bool pdfBug) {
     _pdfjsContext['pdfBug'] = pdfBug;
   }
 
-  static bool get pdfjsNext => _pdfjsContext['pdfjsNext'];
+  static bool get pdfjsNext => _pdfjsContext['pdfjsNext'] as bool;
   static set pdfjsNext(bool pdfjsNext) {
     _pdfjsContext['pdfjsNext'] = pdfjsNext;
   }
 
-  static bool get postMessageTransfers => _pdfjsContext['postMessageTransfers'];
+  static bool get postMessageTransfers => _pdfjsContext['postMessageTransfers'] as bool;
   static set postMessageTransfers(bool postMessageTransfers) {
     _pdfjsContext['postMessageTransfers'] = postMessageTransfers;
   }
 
-  static VERBOSITY_LEVELS get verbosity =>
-      _verbosityLevelsPdfjsToDart[_pdfjsContext['verbosity']];
+  static VERBOSITY_LEVELS get verbosity => _verbosityLevelsPdfjsToDart[_pdfjsContext['verbosity']];
   static set verbosity(VERBOSITY_LEVELS verbosity) {
     _pdfjsContext['verbosity'] = _verbosityLevelsDartToPdfjs[verbosity];
   }
 
-  static int get workerPort => _pdfjsContext['workerPort'];
+  static int get workerPort => _pdfjsContext['workerPort'] as int;
   static set workerPort(int workerPort) {
     _pdfjsContext['workerPort'] = workerPort;
   }
 
-  static String get workerSrc => _pdfjsContext['workerSrc'];
+  static String get workerSrc => _pdfjsContext['workerSrc'] as String;
   static set workerSrc(String workerSrc) {
     _pdfjsContext['workerSrc'] = workerSrc;
   }
@@ -139,13 +135,12 @@ class PDFJS {
 
   @deprecated
   static PDFDocumentLoadingTask getDocument(dynamic src) {
-    JsObject documentTask = _pdfjsContext.callMethod('getDocument', [src]);
+    JsObject documentTask = _pdfjsContext.callMethod('getDocument', [src]) as JsObject;
 
     return PDFDocumentLoadingTask._withJsInternal(documentTask);
   }
 
-  static PDFDocumentLoadingTask getDocumentByDocumentInitParameters(
-      DocumentInitParameters src) {
+  static PDFDocumentLoadingTask getDocumentByDocumentInitParameters(DocumentInitParameters src) {
     // ignore: deprecated_member_use
     return getDocument(src._jsInternal);
   }
@@ -160,8 +155,7 @@ class PDFJS {
     return getDocument(src);
   }
 
-  static PDFDocumentLoadingTask getDocumentByPDFDataRangeTransport(
-      PDFDataRangeTransport src) {
+  static PDFDocumentLoadingTask getDocumentByPDFDataRangeTransport(PDFDataRangeTransport src) {
     // ignore: deprecated_member_use
     return getDocument(src._jsInternal);
   }
@@ -171,9 +165,9 @@ class PDFJS {
   // FOOTGUN: Both this list and the following list must be kept in
   // corresponding order
   static List<int> _pdfjsVerbosityLevels = [
-    _pdfjsContext['VERBOSITY_LEVELS']['errors'],
-    _pdfjsContext['VERBOSITY_LEVELS']['warnings'],
-    _pdfjsContext['VERBOSITY_LEVELS']['infos'],
+    _pdfjsContext['VERBOSITY_LEVELS']['errors'] as int,
+    _pdfjsContext['VERBOSITY_LEVELS']['warnings'] as int,
+    _pdfjsContext['VERBOSITY_LEVELS']['infos'] as int,
   ];
 
   // FOOTGUN: Both this list and the preceding list must be kept in
@@ -193,11 +187,11 @@ class PDFJS {
   // FOOTGUN: Both this list and the following list must be kept in
   // corresponding order
   static List<int> _pdfjsLinkTarget = [
-    _pdfjsContext['LinkTarget']['NONE'],
-    _pdfjsContext['LinkTarget']['SELF'],
-    _pdfjsContext['LinkTarget']['BLANK'],
-    _pdfjsContext['LinkTarget']['PARENT'],
-    _pdfjsContext['LinkTarget']['TOP'],
+    _pdfjsContext['LinkTarget']['NONE'] as int,
+    _pdfjsContext['LinkTarget']['SELF'] as int,
+    _pdfjsContext['LinkTarget']['BLANK'] as int,
+    _pdfjsContext['LinkTarget']['PARENT'] as int,
+    _pdfjsContext['LinkTarget']['TOP'] as int,
   ];
 
   // FOOTGUN: Both this list and the preceding list must be kept in
@@ -210,9 +204,7 @@ class PDFJS {
     LinkTarget.TOP,
   ];
 
-  static Map<int, LinkTarget> _linkTargetPdfjsToDart =
-      Map.fromIterables(_pdfjsLinkTarget, _dartLinkTarget);
+  static Map<int, LinkTarget> _linkTargetPdfjsToDart = Map.fromIterables(_pdfjsLinkTarget, _dartLinkTarget);
 
-  static Map<LinkTarget, int> _linkTargetDartToPdfjs =
-      Map.fromIterables(_dartLinkTarget, _pdfjsLinkTarget);
+  static Map<LinkTarget, int> _linkTargetDartToPdfjs = Map.fromIterables(_dartLinkTarget, _pdfjsLinkTarget);
 }

--- a/lib/src/private.dart
+++ b/lib/src/private.dart
@@ -15,7 +15,7 @@
 part of pdfjs;
 
 Future<S> _promiseToFuture<S>(JsObject promise, {Function transform}) {
-  Completer completer = Completer();
+  Completer<S> completer = Completer();
 
   dynamic valueToDart(dynamic value) {
     if (transform != null) {
@@ -25,8 +25,7 @@ Future<S> _promiseToFuture<S>(JsObject promise, {Function transform}) {
     return value;
   }
 
-  promise
-      .callMethod('then', [(value) => completer.complete(valueToDart(value))]);
+  promise.callMethod('then', [(value) => completer.complete(valueToDart(value) as FutureOr<S>)]);
 
   promise.callMethod('catch', [(err) => completer.completeError(err)]);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfjs_dart",
-  "version": "2.1.266",
+  "version": "2.5.207",
   "description": "Dart bindings for Mozilla's PDF.js library",
   "repository": {
     "type": "git",
@@ -13,6 +13,6 @@
   },
   "homepage": "https://github.com/Workiva/pdfjs_dart",
   "dependencies": {
-    "pdfjs-dist": "2.1.266"
+    "pdfjs-dist": "2.5.207"
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,3 +6,6 @@ homepage: https://github.com/Workiva/pdfjs_dart
 
 environment:
   sdk: '>=2.4.0 <3.0.0'
+
+dependencies:
+  quiver: ">=0.25.0 <3.0.0"


### PR DESCRIPTION
Ported over all the interop code from markup_client's version of 2.5.207.

Not porting over the static pdfjs files, as those are now published to the cdn via https://github.com/Workiva/pdfjs_cdn/. Available here: https://cdn-prod.wdesk.com/pdfjs_cdn/0.1.0/assets/v2.5.207

This interop has been smoke tested against pdfjs 1.10.90+4, 2.5.207 (through markup_client), and 2.7.570.

I think any consumers of this repo are pinned to old versions, so updating this interop shouldn't break anything: https://w-rmconsole.appspot.com/rosie/dependency_search/pdfjs/

### QA Instructions

1. Probably best done locally (or deployed with these branches linked below)
2. Pull this PR as a dependency_override into w_viewer (https://github.com/Workiva/w_viewer/pull/768)
3. Serve graph_app locally, with a dependency override for the w_viewer branch in step 2 (https://github.com/Workiva/graph_app/pull/21916)
4. Smoke test ETE/graph markup viewer/standard pdf viewer and verify existing functionality
    - Ensure that the pdfjs static files loaded are from the CDN, and not from pdfjs_dart package (see [here](https://github.com/Workiva/graph_app/pull/21864#issue-704255632) for how to do that)