### PR TITLE
Release pdfjs_dart 2.5.207+3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pdfjs
-version: 2.5.207+2
+version: 2.5.207+3
 description: Dart bindings for Mozilla's PDF.js library
 homepage: https://github.com/Workiva/pdfjs_dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Remove deprecated authors field from pubspec.yaml](https://github.com/Workiva/pdfjs_dart/pull/30)
	* [Raise the Dart SDK minimum to at least 2.11.0](https://github.com/Workiva/pdfjs_dart/pull/48)


Requested by: Repo Release Cron

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/pdfjs_dart/compare/2.5.207+2...Workiva:release_pdfjs_dart_2.5.207+3
Diff Between Last Tag and New Tag: https://github.com/Workiva/pdfjs_dart/compare/2.5.207+2...2.5.207+3

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6568135994376192/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6568135994376192/?pull_number=114&repo_name=Workiva%2Fpdfjs_dart)