### PR TITLE
Test Dart 2.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/dart_build_image:1
+FROM drydock-prod.workiva.net/workiva/dart_build_image:0.0.0-dart2.18.7
 ARG NPM_TOKEN
 
 RUN apt-get update && apt-get install -y curl


### PR DESCRIPTION
Summary
---
This batch overrides the docker images used to equivalent Dart 2.18 versions.
The goal is to run as many CI runs across the dart ecosystem as possible on 
Dart 2.18 to find and fix errors before releasing a production 2.18 image.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/test_dart_218`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/test_dart_218)