### PR TITLE
raise_min_dart_sdk_2_19

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.18.7, 2.19.6 ]
+        sdk: [ 2.19.6 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
@@ -41,7 +41,7 @@ jobs:
         if: always() && steps.install.outcome == 'success'
 
       - uses: anchore/sbom-action@v0
-        if: ${{ matrix.sdk == '2.19.6' && matrix.os == 'ubuntu' }}
+        if: ${{ matrix.os == 'ubuntu' }}
         with:
           path: ./
           format: cyclonedx-json

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Dart bindings for Mozilla's PDF.js library
 homepage: https://github.com/Workiva/pdfjs_dart
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   quiver: ^3.0.0


### PR DESCRIPTION
# Summary
For Dart packages that have migrated to null safety (full or partial)
we can raise the minimum Dart SDK version to 2.19.0 instead of 2.12.0.
This will allow us to take advantage of new language features as soon as
files are migrated to null safety. We've shown that unmigrated consumers
do not have issues consuming packages with a higher minimum Dart SDK version.
# Changes
- Raise minimum Dart SDK version to 2.19.0
# QA
- [ ] CI passes

[_Created by Sourcegraph batch change `Workiva/raise_min_dart_sdk_2_19`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/raise_min_dart_sdk_2_19)