### PR TITLE
[INTRISK-83943] default isEvalSupported to false

### DIFF
--- a/lib/src/document_init_parameters.dart
+++ b/lib/src/document_init_parameters.dart
@@ -26,7 +26,7 @@ class DocumentInitParameters {
 
   DocumentInitParameters() {
     _jsInternal = JsObject.jsify({});
-    
+
     // https://www.cisecurity.org/advisory/a-vulnerability-in-mozilla-pdfjs-could-allow-for-arbitrary-code-execution_2024-046
     // Vulnerability in Mozilla PDF.js Could Allow for Arbitrary Code Execution when isEvalSupported is set to true for PDF.js versions prior to 4.2.67.
     isEvalSupported = false;

--- a/lib/src/document_init_parameters.dart
+++ b/lib/src/document_init_parameters.dart
@@ -29,7 +29,7 @@ class DocumentInitParameters {
 
     // https://www.cisecurity.org/advisory/a-vulnerability-in-mozilla-pdfjs-could-allow-for-arbitrary-code-execution_2024-046
     // Vulnerability in Mozilla PDF.js Could Allow for Arbitrary Code Execution when isEvalSupported is set to true for PDF.js versions prior to 4.2.67.
-    isEvalSupported = false;
+    _jsInternal?['isEvalSupported'] = false;
   }
 
   TypedData? get data => _jsInternal?['data'] as TypedData?;
@@ -99,11 +99,6 @@ class DocumentInitParameters {
   bool? get withCredentials => _jsInternal?['withCredentials'] as bool?;
   set withCredentials(bool? withCredentials) {
     _jsInternal?['withCredentials'] = withCredentials;
-  }
-
-  bool? get isEvalSupported => _jsInternal?['isEvalSupported'] as bool?;
-  set isEvalSupported(bool? isEvalSupported) {
-    _jsInternal?['isEvalSupported'] = isEvalSupported;
   }
 
   // FOOTGUN: Both this list and the following list must be kept in

--- a/lib/src/document_init_parameters.dart
+++ b/lib/src/document_init_parameters.dart
@@ -26,6 +26,10 @@ class DocumentInitParameters {
 
   DocumentInitParameters() {
     _jsInternal = JsObject.jsify({});
+    
+    // https://www.cisecurity.org/advisory/a-vulnerability-in-mozilla-pdfjs-could-allow-for-arbitrary-code-execution_2024-046
+    // Vulnerability in Mozilla PDF.js Could Allow for Arbitrary Code Execution when isEvalSupported is set to true for PDF.js versions prior to 4.2.67.
+    isEvalSupported = false;
   }
 
   TypedData? get data => _jsInternal?['data'] as TypedData?;
@@ -95,6 +99,11 @@ class DocumentInitParameters {
   bool? get withCredentials => _jsInternal?['withCredentials'] as bool?;
   set withCredentials(bool? withCredentials) {
     _jsInternal?['withCredentials'] = withCredentials;
+  }
+
+  bool? get isEvalSupported => _jsInternal?['isEvalSupported'] as bool?;
+  set isEvalSupported(bool? isEvalSupported) {
+    _jsInternal?['isEvalSupported'] = isEvalSupported;
   }
 
   // FOOTGUN: Both this list and the following list must be kept in


### PR DESCRIPTION
There is a vulnerability in the version of PDFjs used by markup_client, and the graph/grc markup viewers. It has been addressed in a recent version of PDFjs but upgrading is not trivial. Fortunately there is a workaround. Disabling eval support prevents the attack vector.

See the ticket for repro details.

Here is a consumer for testing the fix: https://github.com/Workiva/markup_client/pull/4798