### PR TITLE
Release pdfjs_dart 2.12.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pdfjs
-version: 2.12.3
+version: 2.12.4
 description: Dart bindings for Mozilla's PDF.js library
 homepage: https://github.com/Workiva/pdfjs_dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [publish action](https://github.com/Workiva/pdfjs_dart/pull/187)


Requested by: @ryanelliott-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/pdfjs_dart/compare/2.12.3...Workiva:release_pdfjs_dart_2.12.4
Diff Between Last Tag and New Tag: https://github.com/Workiva/pdfjs_dart/compare/2.12.3...2.12.4

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6568135994376192/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6568135994376192/?repo_name=Workiva%2Fpdfjs_dart&pull_number=188)