### PR TITLE
pin publish action version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,4 +34,4 @@ jobs:
 
   publish:
     name: Publish to pub.dev
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1.6.5


### PR DESCRIPTION
The `dart-lang/setup-dart` publish GHA recently added a dependency on an action that is not certified by github and therefor not approved for use on Workiva repositories (`flutter-actions/setup-flutter`). Pinning the action to an older version for now and will request review of the action to be used in the future. 