### PR TITLE
Release pdfjs_dart 2.12.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pdfjs
-version: 2.12.5
+version: 2.12.6
 description: Dart bindings for Mozilla's PDF.js library
 homepage: https://github.com/Workiva/pdfjs_dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [add changelog md](https://github.com/Workiva/pdfjs_dart/pull/191)


Requested by: @ryanelliott-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/pdfjs_dart/compare/2.12.5...Workiva:release_pdfjs_dart_2.12.6
Diff Between Last Tag and New Tag: https://github.com/Workiva/pdfjs_dart/compare/2.12.5...2.12.6

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6568135994376192/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6568135994376192/?repo_name=Workiva%2Fpdfjs_dart&pull_number=192)