### PR TITLE
Release pdfjs_dart 2.12.8

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pdfjs
-version: 2.12.7
+version: 2.12.8
 description: Dart bindings for Mozilla's PDF.js library
 homepage: https://github.com/Workiva/pdfjs_dart
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [cleanup_workiva_build](https://github.com/Workiva/pdfjs_dart/pull/195)


Requested by: Repo Release Cron

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/pdfjs_dart/compare/2.12.7...Workiva:release_pdfjs_dart_2.12.8
Diff Between Last Tag and New Tag: https://github.com/Workiva/pdfjs_dart/compare/2.12.7...2.12.8

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6568135994376192/logs/)