### PR TITLE
unpin publish action now that it has been approved by infosec

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,4 +34,4 @@ jobs:
 
   publish:
     name: Publish to pub.dev
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1.6.5
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1


### PR DESCRIPTION
The unapproved dependency of the publish action has been approved (at the latest commit) by Workiva's infosec team (https://jira.atl.workiva.net/browse/RED-6967) and release management team (https://jira.atl.workiva.net/browse/RM-310423) meaning it can be unpinned.