### PR TITLE
INTRISK-93210 - Update Bot GHA slack channel for Testing Evidence non-markup channels

### DIFF
--- a/.github/workflows/check-prs.yaml
+++ b/.github/workflows/check-prs.yaml
@@ -13,4 +13,4 @@ jobs:
     secrets: inherit
     uses: Workiva/gha-automated-pr-check/.github/workflows/automated-pr-check.yaml@v0.1.3
     with:
-      slack-alert-channel: 'C095QEHMWES' #grc-bot-prs-graph
+      slack-alert-channel: 'C0943S449B3' #support-grc-testing-evidence


### PR DESCRIPTION
### Problem / Feature  
Update Bot GHA slack channel for Testing Evidence non-markup channels

### Solution  
Update the Bot GHA to point to the ##support-grc-testing-evidence channel (C0943S449B3).
 
### What To Test  

### Test Coverage  
- [ ] Passing CI